### PR TITLE
fix: renamed base_objects to core

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,11 @@
 # TODO
 
+Model refactor:
+
+- Refactor invasions as soon as the endpoint is fixed, if it's an endpoint problem
+
+Else:
+
 - Implement all models/endpoints
 endpoints
 - Implement Item- hierarchy and types:

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,5 @@
 # TODO
 
-Model refactor:
-
-- Refactor invasions as soon as the endpoint is fixed, if it's an endpoint problem
-
-Else:
-
 - Implement all models/endpoints
 endpoints
 - Implement Item- hierarchy and types:

--- a/examples/worldstate/custom_models.py
+++ b/examples/worldstate/custom_models.py
@@ -5,7 +5,7 @@ from typing import Literal, Optional
 from msgspec import field  # use this to rename response keys
 
 from warframe.worldstate import WorldstateClient
-from warframe.worldstate.common.base_objects import (
+from warframe.worldstate.common.core import (
     SingleQueryModel,
 )  # this import might change
 
@@ -29,9 +29,9 @@ class CustomCambionDrift(SingleQueryModel):
 
 async def main():
     async with WorldstateClient() as client:
-        arbi = await client.query(CustomCambionDrift)
+        ccd = await client.query(CustomCambionDrift)
 
-        print(arbi)
+        print(ccd)
 
 
 if __name__ == "__main__":

--- a/warframe/worldstate/client.py
+++ b/warframe/worldstate/client.py
@@ -108,7 +108,7 @@ class WorldstateClient:
 
     async def query_list_of(
         self, cls: Type[SupportsMultiQuery], language: Optional[Language] = None
-    ) -> Optional[List[SupportsMultiQuery]]:
+    ) -> List[SupportsMultiQuery]:
         """Queries the model of type `MultiQueryModel` to return its corresponding object.
 
         Args:

--- a/warframe/worldstate/common/__init__.py
+++ b/warframe/worldstate/common/__init__.py
@@ -1,2 +1,2 @@
 from .types_ import *
-from .base_objects import *
+from .core import *

--- a/warframe/worldstate/common/core.py
+++ b/warframe/worldstate/common/core.py
@@ -14,6 +14,31 @@ def _decode_hook(type: Type, obj: Any) -> Any:
     return obj
 
 
+def get_start_string(activation: datetime) -> str:
+    """Returns an short time formatted string based on the activation.
+
+    Args:
+        activation (datetime): The time the Event XYZ started
+
+    Returns:
+        str: The short time formatted string of the time in between now and when the event started.
+    """
+    time_in_between = datetime.now() - activation
+
+    days = time_in_between.days
+    hours, remainder = divmod(time_in_between.seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+
+    time_components = [(days, "d"), (hours, "h"), (minutes, "m"), (seconds, "s")]
+    formatted_time = ""
+
+    for t, suffix in time_components:
+        if t != 0:
+            formatted_time += f"{t}{suffix} "
+
+    return formatted_time.strip()
+
+
 class WorldstateObject(msgspec.Struct, rename="camel"):
     """
     Base class for every model-related object.

--- a/warframe/worldstate/models/alert.py
+++ b/warframe/worldstate/models/alert.py
@@ -1,37 +1,17 @@
-from datetime import datetime
-from typing import List, Optional
+from typing import List
 
-from ..common import ItemRewardType, MultiQueryModel
+from ..common import ItemRewardType, MultiQueryModel, TimedEvent
 from .mission import Mission
 
 __all__ = ["Alert"]
 
 
-class Alert(MultiQueryModel):
+class Alert(MultiQueryModel, TimedEvent):
     __endpoint__ = "/alerts"
 
     # required
-    activation: datetime
-    "The time the mission began"
-
-    expiry: datetime
-    "The time the mission ends"
-
     mission: Mission
     "The mission that corresponds to this Alert"
 
     reward_types: List[ItemRewardType]
     "A list of reward types"
-
-    # optional
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string representing the start of the alert"
-
-    active: Optional[bool] = None
-    "Whether the alert is still active or not"
-
-    eta: Optional[str] = None
-    "Short-formatted string estimating the time until the Alert is closed"
-
-    expired: Optional[bool] = None
-    "Whether the mission is expired or not"

--- a/warframe/worldstate/models/arbitration.py
+++ b/warframe/worldstate/models/arbitration.py
@@ -1,37 +1,40 @@
-from datetime import datetime
 from typing import Optional
 
 from msgspec import field
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 from ..enums import Faction, MissionType
 
 __all__ = ["Arbitration"]
 
 
-class Arbitration(SingleQueryModel):
+class Arbitration(SingleQueryModel, TimedEvent):
+    """
+    UNSTABLE
+    """
+
     __endpoint__ = "/arbitration"
 
     # required
-    activation: datetime
-    "The time the mission began."
-    expiry: datetime
-    "The time the mission ends."
     node: str
+    "The localized plain name for the node the Arbitration is on."
+
+    node_key: str
     "The plain name for the node the Arbitration is on."
+
     faction: Faction = field(
         name="enemy"
     )  # it's not called faction at the endpoint, instead it's called enemy
     "The Faction of the corresponding mission."
+
     archwing_required: bool = field(name="archwing")
     "Whether an archwing is required in order to play the mission"
+
     is_sharkwing: bool = field(name="sharkwing")
     "Whether the mission takes place in a submerssible mission"
 
-    # optional
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string representing the start of the Arbitration."
-    active: Optional[bool] = None
-    "Whether the alert is still active or not."
-    mission_type: Optional[MissionType] = None
+    mission_type: str = field(name="type")
+    "The localized MissionType of the given mission (Capture, Spy, etc.)"
+
+    mission_type_key: MissionType = field(name="typeKey")
     "The MissionType of the given mission (Capture, Spy, etc.)"

--- a/warframe/worldstate/models/archon_hunt.py
+++ b/warframe/worldstate/models/archon_hunt.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-from typing import List, Optional
+from typing import List
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 from ..enums import Faction, MissionType
-from .reward import Reward
 
 __all__ = ["ArchonHunt"]
 
@@ -12,55 +10,41 @@ class ArchonHuntMission(SingleQueryModel):  # archon hunt's mission is pretty di
     # required
     node: str
     "The localized node string"
-    type: MissionType
+
+    node_key: str
+    "The node string"
+
+    type: str
+    "The localized MissionType of the given mission (Capture, Spy, etc.)"
+
+    type_key: MissionType
     "The MissionType of the given mission (Capture, Spy, etc.)"
-    nightmare: bool
-    "Whether the mission is a nightmare mission"
+
     archwing_required: bool
     "Whether an archwing is required in order to play the mission"
 
-    # optional
-    reward: Optional[Reward] = None
-    "The mission's reward"
-    is_sharkwing: Optional[bool] = None
-    "Whether the mission takes place in a submerssible mission"
-    enemy_spec: Optional[str] = None
-    "Enemy specification for the mission"
-    level_override: Optional[str] = None
-    "Override for the map on this mission"
-    advanced_spawners: Optional[List[str]] = None
+    advanced_spawners: List[str]
     "Array of strings denoting extra spawners for a mission"
-    required_items: Optional[List[str]] = None
+
+    required_items: List[str]
     "Items required to enter the mission"
-    consume_required_items: Optional[bool] = None
-    "Whether the required items are consumed"
-    leaders_always_allowed: Optional[bool] = None
-    "Whether leaders are always allowed"
-    level_auras: Optional[List[str]] = None
+
+    level_auras: List[str]
     "Affectors for this mission"
 
+    is_sharkwing: bool
+    "Whether the mission takes place in a submerssible mission"
 
-class ArchonHunt(SingleQueryModel):
+
+class ArchonHunt(SingleQueryModel, TimedEvent):
     __endpoint__ = "/archonHunt"
 
     # required
-    activation: datetime
-    "The time the Archon Hunt started"
-    expiry: datetime
-    "The time the Archon Hunt ends"
     missions: List[ArchonHuntMission]
     "The list of missions that have to be played in order to queue up for the rewards"
+
     boss: str
     "The archon you are going to fight against"
+
     faction: Faction
     "The faction you're up against: Narmer"
-    expired: bool
-    "Whether the Archon Hunt has ended"
-    eta: str
-    "Short-formatted string estimating the time until the Alert is closed."
-
-    # optional
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string representing the start of the Archon Hunt"
-    active: Optional[bool] = None
-    "Whether the alert is still active or not"

--- a/warframe/worldstate/models/cambion_drift.py
+++ b/warframe/worldstate/models/cambion_drift.py
@@ -1,23 +1,13 @@
-from datetime import datetime
-from typing import Literal, Optional
+from typing import Literal
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 
 __all__ = ["CambionDrift"]
 
 
-class CambionDrift(SingleQueryModel):
+class CambionDrift(SingleQueryModel, TimedEvent):
     __endpoint__ = "/cambionCycle"
 
     # required
-    expiry: datetime
-    "The time the Cycle ends"
-
-    activation: datetime
-    "The time the new rotation of the cycle started"
-
     state: Literal["vome", "fass"]
     'The state of the Cambion Drift. ("vome" or "fass")'
-
-    # optional
-    time_left: Optional[str] = None

--- a/warframe/worldstate/models/cetus.py
+++ b/warframe/worldstate/models/cetus.py
@@ -1,33 +1,17 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 
 __all__ = ["Cetus"]
 
 
-class Cetus(SingleQueryModel):
+class Cetus(SingleQueryModel, TimedEvent):
     __endpoint__ = "/cetusCycle"
 
     # required
-    expiry: datetime
-    "The time the Cycle ends"
-
     is_day: bool
     "Whether it is currently day on the Plains of Eidolon"
-
-    time_left: str
-    "Short formatted time string on how much time is left on the current cycle"
-
-    # optional
-    activation: Optional[datetime] = None
-    "The time the new rotation of the cycle started"
-
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string representing the start of the alert"
-
-    short_string: Optional[str] = None
-    "Short-time-formatted duration string representing the start of the alert"
 
     @property
     def state(self):

--- a/warframe/worldstate/models/counted_item.py
+++ b/warframe/worldstate/models/counted_item.py
@@ -1,4 +1,4 @@
-from ..common.base_objects import SingleQueryModel
+from ..common import SingleQueryModel
 
 __all__ = ["CountedItem"]
 

--- a/warframe/worldstate/models/daily_deal.py
+++ b/warframe/worldstate/models/daily_deal.py
@@ -1,12 +1,9 @@
-from datetime import datetime
-from typing import Optional
-
-from ..common import MultiQueryModel
+from ..common import MultiQueryModel, TimedEvent
 
 __all__ = ["DailyDeal"]
 
 
-class DailyDeal(MultiQueryModel):
+class DailyDeal(MultiQueryModel, TimedEvent):
     __endpoint__ = "/dailyDeals"
 
     # required
@@ -30,9 +27,3 @@ class DailyDeal(MultiQueryModel):
 
     discount: int
     "The discount as %"
-
-    expiry: datetime
-    "The time the Daily Deal ends ends"
-
-    # optional
-    activation: Optional[datetime] = None

--- a/warframe/worldstate/models/event.py
+++ b/warframe/worldstate/models/event.py
@@ -5,24 +5,14 @@ from msgspec import field
 
 from .reward import Reward
 
-from ..common import MultiQueryModel
+from ..common import MultiQueryModel, TimedEvent
 from ..enums import MissionType, Faction, Syndicate
 
 __all__ = ["Event"]
 
 
-class Event(MultiQueryModel):
-    activation: Optional[datetime] = None
-    "The time the Event started"
-
-    expiry: Optional[datetime] = None
-    "The time the Event"
-
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string of the start of the Fissure"
-
-    active: Optional[bool] = None
-    "Whether the event is currently active"
+class Event(MultiQueryModel, TimedEvent):
+    __endpoint__ = "/events"
 
     maximum_score: Optional[int] = None
     "Maximum score to complete the event"

--- a/warframe/worldstate/models/fissure.py
+++ b/warframe/worldstate/models/fissure.py
@@ -1,42 +1,40 @@
-from datetime import datetime
-from typing import Optional
-
 from msgspec import field
-from ..common import MultiQueryModel, FissureTier, FissureTierNumber
-from ..enums import MissionType, Faction
+
+from ..common import FissureTier, FissureTierNumber, MultiQueryModel, TimedEvent
+from ..enums import Faction, MissionType
 
 __all__ = ["Fissure"]
 
 
-class Fissure(MultiQueryModel):
+class Fissure(MultiQueryModel, TimedEvent):
     __endpoint__ = "/fissures"
 
     # required
-    activation: datetime
-    "The time the Fissure started"
-    expiry: datetime
-    "The time the fissure ends"
     node: str
     "The localized node string"
-    expired: bool
-    "Whether the fissure is still present"
-    eta: str
-    "Short-formatted string estimating the time until the Fissure is closed"
-    mission_type: MissionType
+
+    node: str
+    "The node string"
+
+    mission_type: str
+    "The localized game mode that the mission/node houses"
+
+    mission_type_key: MissionType = field(name="missionKey")
     "The game mode that the mission/node houses"
+
     tier: FissureTier
     "Tier of the mission (Lith, Meso, etc.)"
+
     tier_num: FissureTierNumber
     "The Numeric tier corresponding to the tier"
-    faction: Faction = field(name="enemy")
+
+    faction: str = field(name="enemy")
+    "The localized faction that houses the node/mission"
+
+    faction_key: Faction = field(name="enemyKey")
     "The faction that houses the node/mission"
+
     is_steel_path: bool = field(name="isHard")
     "Whether the mission of the Fissure is on is on the Steel Path"
     is_railjack: bool = field(name="isStorm")
     "Whether the mssion of the Fissure is a Railjack mission"
-
-    # optional
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string of the start of the Fissure"
-    active: Optional[bool] = None
-    "Whether the fissure is currently active"

--- a/warframe/worldstate/models/flash_sale.py
+++ b/warframe/worldstate/models/flash_sale.py
@@ -3,20 +3,17 @@ from typing import Optional
 
 from msgspec import field
 
-from ..common import MultiQueryModel
+from ..common import MultiQueryModel, TimedEvent
 
 __all__ = ["FlashSale"]
 
 
-class FlashSale(MultiQueryModel):
+class FlashSale(MultiQueryModel, TimedEvent):
     __endpoint__ = "/flashSales"
 
     # required
     item: str
     "The Item that is being sold"
-
-    eta: str
-    "Short-formatted string estimating the time until the Flash Sale ends"
 
     discount: int
     "The discount of the item."
@@ -31,11 +28,5 @@ class FlashSale(MultiQueryModel):
     is_popular: Optional[bool] = None  # docs are wrong
     "Whether the item is popular"
 
-    expired: Optional[bool] = None
-    "Whether the item is expired or not"
-
     is_in_market: Optional[bool] = field(name="isShownInMarket", default=None)
     "Whether the item is available/shown in the market. Most likely to be `True`"
-
-    expiry: Optional[datetime] = None
-    "The time the Flash Sale ends"

--- a/warframe/worldstate/models/invasion.py
+++ b/warframe/worldstate/models/invasion.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from msgspec import field
 
-from ..common import ItemRewardType, MultiQueryModel, WorldstateObject
+from ..common import ItemRewardType, MultiQueryModel, TimedEvent, WorldstateObject
 from ..enums import Faction
 from .reward import Reward
 
@@ -12,9 +12,12 @@ __all__ = ["Invasion"]
 
 class InvasionMember(WorldstateObject):
     # optional
-    reward: Optional[Reward] = None
+    reward: Reward
     "The reward of the mission."
-    faction: Optional[Faction] = None
+
+    faction: str
+    "The localized faction that houses the node/mission"
+    faction_key: Faction
     "The faction that houses the node/mission"
 
 
@@ -32,33 +35,48 @@ class Invasion(MultiQueryModel):
     # required
     activation: datetime
     "The time the Invasion began"
+
     completed: bool
     "Whether the Invasion is over"
+
     completion_percentage: float = field(name="completion")
     "Percantage of the Invasion's completion"
+
     count: int
     "How many fights have happened"
+
     description: str = field(name="desc")
     "The Invasion's description"
+
     eta: str
     "Short-formatted string estimating the time until the Invasion is closed"
+
     node: str
     "The localized node string"
+
+    node_key: str
+    "The node string"
+
     required_runs: int
     "The amount of runs required to qualify for the reward. (most likely 3)"
+
     vs_infested: bool = field(name="vsInfestation")
     "Whether the fight is against infested enemies"
+    attacker: Attacker
+    "The invading faction information"
+
+    defender: Defender
+    "The defending faction information"
 
     # optional
     expiry: Optional[datetime] = None
     "The time the Invasion ends"
+
     start_string: Optional[str] = None
     "Short-time-formatted duration string of the start of the Invasion"
+
     active: Optional[bool] = None
     "Whether the invasion is currently active"
-    attacker: Optional[Attacker] = None
-    "The invading faction information"
-    defender: Optional[Defender] = None
-    "The defending faction information"
+
     reward_types: Optional[List[ItemRewardType]] = None
     "A list of reward types"

--- a/warframe/worldstate/models/mission.py
+++ b/warframe/worldstate/models/mission.py
@@ -19,7 +19,10 @@ class Mission(SingleQueryModel):
     faction: Faction
     "The faction that houses the node/mission"
 
-    type: MissionType
+    type: str
+    "The localized MissionType of the given mission (Capture, Spy, etc.)"
+
+    type_key: MissionType
     "The MissionType of the given mission (Capture, Spy, etc.)"
 
     nightmare: bool

--- a/warframe/worldstate/models/orb_vallis.py
+++ b/warframe/worldstate/models/orb_vallis.py
@@ -1,27 +1,21 @@
 from datetime import datetime
 from typing import Literal, Optional
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 
 __all__ = ["OrbVallis"]
 
 
-class OrbVallis(SingleQueryModel):
+class OrbVallis(SingleQueryModel, TimedEvent):
     __endpoint__ = "/vallisCycle"
 
     # required
-    expiry: datetime
-    "The time the Cycle ends"
-
-    time_left: str
-    "Short formatted time string on how much time is left on the current cycle"
-
     is_warm: bool
     "Whether it is currently warm"
 
-    # optional
-    activation: Optional[datetime] = None
-    "The time the new rotation of the cycle started"
-
-    state: Optional[Literal["warm", "cold"]] = None
-    "The state of the vallis (warm/cold)"
+    @property
+    def state(self) -> Literal["warm", "cold"]:
+        """
+        The state of the Plains of Eidolon ("warm" or "cold")
+        """
+        return "warm" if self.is_warm else "cold"

--- a/warframe/worldstate/models/sortie.py
+++ b/warframe/worldstate/models/sortie.py
@@ -1,9 +1,8 @@
-from datetime import datetime
 from typing import List, Optional
 
 from msgspec import field
 
-from ..common import SingleQueryModel
+from ..common import SingleQueryModel, TimedEvent
 from ..enums import MissionType, Faction
 
 __all__ = ["Sortie"]
@@ -11,10 +10,10 @@ __all__ = ["Sortie"]
 
 class SortieMission(SingleQueryModel):
     node: str
-    "The node the mission is on"
+    "The localized node the mission is on"
 
-    type: MissionType = field(name="missionType")
-    "The Type of the mission"
+    type: str = field(name="missionType")
+    "The localized Type of the mission"
 
     modifier: str
     "The modifier applied to the mission"
@@ -23,35 +22,15 @@ class SortieMission(SingleQueryModel):
     "The description of the modifier"
 
 
-class Sortie(SingleQueryModel):
+class Sortie(SingleQueryModel, TimedEvent):
     __endpoint__ = "/sortie"
 
     # required
     boss: str
     "The boss you're up against"
 
-    activation: datetime
-    "The time the Sortie started"
-
-    expiry: datetime
-    "The time the Sortie ends"
-
     missions: List[SortieMission] = field(name="variants")
     "The 3 missions you have to play in order to get the reward"
 
     faction: Faction
     "The Faction you're up against"
-
-    expired: bool
-    "Whether the Sortie is still active"
-
-    eta: str
-    "Short-formatted string estimating the time until the Sortie ends"
-
-    # optional
-    start_string: Optional[str] = None
-    "Short-time-formatted duration string of the start of the Fissure"
-
-    @property
-    def active(self):
-        return not self.expired

--- a/warframe/worldstate/models/void_trader.py
+++ b/warframe/worldstate/models/void_trader.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from msgspec import field
 
-from ..common import SingleQueryModel, WorldstateObject
+from ..common import SingleQueryModel, WorldstateObject, TimedEvent
 
 __all__ = ["VoidTrader"]
 
@@ -19,28 +19,12 @@ class InventoryItem(WorldstateObject):
     "The cost of credits"
 
 
-class VoidTrader(SingleQueryModel):
+class VoidTrader(SingleQueryModel, TimedEvent):
     __endpoint__ = "/voidTrader"
 
     # required
-    start_string: str
-    "Short-time-formatted duration string of the arrival of the Void Trader"
-
-    active: bool
-    "Whether the Void Trader is currently active"
-
     location: str
     "The Relay on which the Void Trader is on"
 
     inventory: List[InventoryItem]
     "The Void Trader's inventory"
-
-    end_string: str
-    "Short-time-formatted duration string of the department of the Void Trader"
-
-    # optional
-    arrival: Optional[datetime] = field(name="activation", default=None)
-    "The time the Void Trader arrived"
-
-    department: Optional[datetime] = field(name="expiry", default=None)
-    "The time the Void Trader departs"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Fixes the OPtional "spamming" on events that have actications and expiries. The calculations are now done internal and do not rely on the API.

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[I don't think so?]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[Yes, should]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix/Feature]**
